### PR TITLE
build: bundle assets into dist, load from there

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "tsc"
+    "build": "tsc && cpx --clean \"assets/**\" dist/assets/"
   },
   "files": [
     "dist/**/*.js",
@@ -16,6 +16,7 @@
   ],
   "devDependencies": {
     "@types/node": "^22.9.4",
+    "cpx": "^1.5.0",
     "typescript": "^5.7.2",
     "yaml": "^2.6.1"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "tsc && cpx --clean \"assets/**\" dist/assets/"
+    "build": "tsc"
   },
   "files": [
     "dist/**/*.js",
@@ -16,7 +16,6 @@
   ],
   "devDependencies": {
     "@types/node": "^22.9.4",
-    "cpx": "^1.5.0",
     "typescript": "^5.7.2",
     "yaml": "^2.6.1"
   }

--- a/src/load-saints.ts
+++ b/src/load-saints.ts
@@ -32,10 +32,10 @@ type RawSaints = Record<
 
 export function loadSaints(lang: string): Saints {
   const calendar: RawCalendar = parse(
-    readFileSync("./assets/calendar.yml", "utf-8")
+    readFileSync(__dirname + "/assets/calendar.yml", "utf-8")
   );
   const latinSaints: LatinSaints = parse(
-    readFileSync(`./assets/saints/la_VA.yml`, "utf-8")
+    readFileSync(__dirname + "/assets/saints/la_VA.yml", "utf-8")
   );
 
   const saints: Saints = {};

--- a/src/load-saints.ts
+++ b/src/load-saints.ts
@@ -32,10 +32,10 @@ type RawSaints = Record<
 
 export function loadSaints(lang: string): Saints {
   const calendar: RawCalendar = parse(
-    readFileSync(__dirname + "/assets/calendar.yml", "utf-8")
+    readFileSync(__dirname + "/../assets/calendar.yml", "utf-8")
   );
   const latinSaints: LatinSaints = parse(
-    readFileSync(__dirname + "/assets/saints/la_VA.yml", "utf-8")
+    readFileSync(__dirname + "/../assets/saints/la_VA.yml", "utf-8")
   );
 
   const saints: Saints = {};


### PR DESCRIPTION
Raw data about the liturgical calendar and the feasts of the saints is stored in `/assets`. `loadSaints()` tries to load from there by giving a relative path. When using this library as a dependency (or in any process not running at this repository's root) that relative path lookup will fail.

Here, we:
- load the files from absolute paths based on the `__dirname` of the source file, and
- add an asset copying step to the build script so that `/assets` ends up in the `/dist`.

For the former, my impression is that Node handles the cross-platform-ing of the paths for you, so we can naively concatenate. (Many sources suggest using the `path` module, but given that the hard-coded POSIX-style paths were working fine, this may not be strictly necessary?)

For the latter, we are forced to add a dev dependency (`cpx`) for copying the files over. Writing a simple `cp` or `rsync` would work on POSIX systems, but not Windows.

@ntvangoor you develop on Windows, right? Please let me know if this works properly on your machine. Happy to adjust as necessary.