### PR TITLE
calendar: use title from specified language

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export type Calendar = Record<
   Record<number, LiturgicalDay & { commemorations: Commemoration[] }>
 >;
 
-export default function generateCalendar(year: number, lang: string): Calendar {
+export default function generateCalendar(year: number, lang: string = 'la_VA'): Calendar {
   return new Calendar_(
     year,
     lang,

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,7 @@ const propers: Propers = {
 
 class Calendar_ {
   private year: number;
+  private lang: string;
   private propers: Propers;
   private saints: Saints;
   private advent: Date;
@@ -198,6 +199,7 @@ class Calendar_ {
     propers: Propers
   ) {
     this.year = year;
+    this.lang = lang;
     this.propers = propers;
     this.saints = loadSaints(lang);
     this.calculateAdvent();
@@ -341,6 +343,9 @@ class Calendar_ {
     dataItem: DataItem,
     class_: 1 | 2 | 3 | 4
   ) {
+    if ("title" in dataItem && this.lang === "nl_NL" && "title_" in dataItem) {
+      dataItem.title = dataItem.title_;
+    }
     if (type == "saints") {
       const saint = this.saints[date.getMonth() + 1][date.getDate()][0];
       this.set(date, {
@@ -380,6 +385,9 @@ class Calendar_ {
     dataItem: DataItem,
     class_: 1 | 2 | 3 | 4
   ) {
+    if ("title" in dataItem && this.lang === "nl_NL" && "title_" in dataItem) {
+      dataItem.title = dataItem.title_;
+    }
     let i = 0;
     while (date.getTime() <= end.getTime()) {
       if (

--- a/src/load-saints.ts
+++ b/src/load-saints.ts
@@ -37,6 +37,10 @@ export function loadSaints(lang: string): Saints {
   const latinSaints: LatinSaints = parse(
     readFileSync(`./assets/saints/la_VA.yml`, "utf-8")
   );
+  const langSaints: RawSaints | null =
+    lang === 'la_VA'
+    ? null
+    : parse(readFileSync(`./assets/saints/${lang}.yml`, "utf-8"));
 
   const saints: Saints = {};
   for (let class_ = 1; class_ <= 4; class_++) {
@@ -51,7 +55,7 @@ export function loadSaints(lang: string): Saints {
           saints[month] ??= {};
           saints[month][day] ??= [];
           saints[month][day].push({
-            title: id.replace("H. ", "H.\u00A0"),
+            title: langSaints ? langSaints[id].name : id,
             subtitle:
               typeof saint.titles === "string"
                 ? saint.titles


### PR DESCRIPTION
Previously, we always used the Latin `id` in the `title` field. Here, we respect the `lang` argument and use it to load a translation file if needed.

Replacing of the space after "H." (Dutch for "S." saint title) seemed vestigial, so we take it out. Let me know if that's in error, and what the intended behavior there is.

Related: am I correct in understanding `saints/la_VA.yml` to be metadata about individual events/feasts with fixed dates, and `saints/nl_NL.yml` to be an actual translation file? Of both saints _and_ other feast days? If yes, I might do a light rename/moving for clarity, if you're not opposed.

This has a small implicit conflict with #1. Happy to resolve after one or the other gets merged.

EDIT: ~~I guess as-is this PR only applies to feasts with fixed dates, not the ones generated through `calendar-data.ts`. Investigating...~~ Patched in 80789de. See also the commit message there, let me know if you have thoughts/opinions about a potential restructuring of the "dynamic" feast translations.