### PR TITLE
calendar: use correct enum when filling propers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,7 @@ class Calendar_ {
         delete proper.occurence;
         this.set(date, {
           ...proper,
-          type: "feest",
+          type: "festum",
           class: class_,
         });
       }


### PR DESCRIPTION
A little bit surprising that `tsc` does not complain about this. It seems to recognize the type of `type` correctly in the context...

Likely missed during the translations in 6f72449.